### PR TITLE
Fix symbol type

### DIFF
--- a/x86doc2docset.py
+++ b/x86doc2docset.py
@@ -53,11 +53,11 @@ def parse_index(fp, root=None):
 
         for instr in name.split(':'):
             logger.info('Found "%s" (path: %s)', instr, path)
-            yield (instr, 'instruction', path)
+            yield (instr, 'Instruction', path)
             if root and not SIMPLE_INSTR_PATTERN.match(instr):
                 try:
                     with open(os.path.join(root, path), mode='r') as f:
-                        yield from ((x, 'instruction', path)
+                        yield from ((x, 'Instruction', path)
                                     for x in parse_combined(f))
                 except ValueError:
                     logger.warning('Did not find table column index for '


### PR DESCRIPTION
With this change Zeal shows entries with correct type instead of unknown:

![image](https://user-images.githubusercontent.com/714940/92330872-569e2780-f040-11ea-809c-95c53c446b6e.png)

_P.S. You may want to regenerate the docset as there's May 2019 version of the doc available._